### PR TITLE
Updated Spanish comments to English in XmlRpcConnections.js

### DIFF
--- a/XmlRpcConnections.js
+++ b/XmlRpcConnections.js
@@ -54,7 +54,7 @@ XmlRpcBaseConn.prototype.stopCallback = function () {
 };
 
 /**
- * Chiamato quando il server xmlrpc risponde correttamente
+ * Called when the server responds correctly xmlrpc
  */
 XmlRpcBaseConn.prototype.successCallback = function (xmlRpcResponseObj, jsParsedObj) {
 	if(this.isStopped == true) return; //se è stata stoppata non fare nulla
@@ -65,7 +65,7 @@ XmlRpcBaseConn.prototype.successCallback = function (xmlRpcResponseObj, jsParsed
 };
 
 /**
- * Chiamato nel caso di errore
+ * Called in case of error
  */
 XmlRpcBaseConn.prototype.errorCallback = function (faultCode, faultString) {
 	if(this.isStopped == true) return; //se è stata stoppata non fare nulla
@@ -112,7 +112,7 @@ AddBlogConn.prototype.execute = function () {
 };
 
 /**
- * Chiamato nel caso di errore nell'aggiunta di un blog
+ * Called in case of error in the addition of a blog
  */
 AddBlogConn.prototype.errorCallback = function (faultCode, faultString) {
 	if(this.isStopped == true) return; //se è stata stoppata non fare nulla


### PR DESCRIPTION
Thanks for doing this.  I am trying to use this framework from a mobile app to talk to WordPress.  Anyway, while reading the code to try to understand how to use it to post a comment, I saw the Spanish comments and converted them to English to help myself understand using Google Translate.  Anyway, I thought it fitting to share back, even though it's just a small thing.

Thanks again for your work.
